### PR TITLE
Update batik-codec to 1.8

### DIFF
--- a/victor/build.gradle
+++ b/victor/build.gradle
@@ -37,7 +37,9 @@ repositories {
 // Batik dependencies
 
 dependencies {
-    compile 'org.apache.xmlgraphics:batik-codec:1.7'
+    compile 'org.apache.xmlgraphics:batik-codec:1.8'
+    compile 'org.apache.xmlgraphics:batik-anim:1.8'
+    compile 'org.apache.xmlgraphics:xmlgraphics-commons:2.0.1'
     testCompile 'junit:junit:4.11'
 }
 

--- a/victor/src/main/groovy/com/trello/victor/SVGResource.groovy
+++ b/victor/src/main/groovy/com/trello/victor/SVGResource.groovy
@@ -16,11 +16,11 @@
 
 package com.trello.victor
 
+import org.apache.batik.anim.dom.SAXSVGDocumentFactory
 import org.apache.batik.bridge.BridgeContext
 import org.apache.batik.bridge.UnitProcessor
 import org.apache.batik.bridge.UserAgent
 import org.apache.batik.bridge.UserAgentAdapter
-import org.apache.batik.dom.svg.SAXSVGDocumentFactory
 import org.apache.batik.util.XMLResourceDescriptor
 import org.gradle.api.logging.Logging
 import org.w3c.dom.svg.SVGDocument


### PR DESCRIPTION
With Batik 1.7 I had problems converting the following SVG file: https://gist.github.com/eugenkiss/7ae6744e8aec88119ae0
It would result in a completely black PNG. Batik 1.8 handles the SVG correctly.

I installed the Victor library with updated Batik dependencies to my local maven repository, tested Victor with the problematic SVG and now it's generated correctly.

Would it be possible to push a new Victor version to jCenter?