### PR TITLE
Bump to v1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 Change Log
 ==========
 
+1.1.1
+-----
+*2021-03-24*
+
+There are no differences between 1.1.0 and 1.1.1; we simply moved to a different host, and I wanted
+to make sure there was no confusion when switching over (since builds will fail now if you keep
+trying to access this via jcenter).
+
+- ([#78](https://github.com/trello/victor/pull/78)) Moved to Gradle publishing portal
+
 1.1.0
 -----
 *2020-05-08*

--- a/README.md
+++ b/README.md
@@ -15,10 +15,12 @@ Add the following to your `build.gradle`:
 ```gradle
 buildscript {
     repositories {
-        jcenter()
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
     }
     dependencies {
-        classpath 'com.trello:victor:1.1.0'
+        classpath 'com.trello:victor:1.1.1'
     }
 }
 

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -16,10 +16,12 @@
 
 buildscript {
     repositories {
-        jcenter()
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
     }
     dependencies {
-        classpath 'com.trello:victor:1.1.0'
+        classpath 'com.trello:victor:1.1.1'
     }
 }
 

--- a/sample/build.gradle.kts.example
+++ b/sample/build.gradle.kts.example
@@ -16,10 +16,12 @@
 
 buildscript {
     repositories {
-        jcenter()
+        maven {
+            url = uri("https://plugins.gradle.org/m2/")
+        }
     }
     dependencies {
-        classpath("com.trello:victor:1.1.0")
+        classpath("com.trello:victor:1.1.1")
     }
 }
 

--- a/victor/build.gradle
+++ b/victor/build.gradle
@@ -50,7 +50,7 @@ dependencies {
 // Plugin publishing
 
 group = 'com.trello'
-version = '1.1.0-SNAPSHOT'
+version = '1.1.1-SNAPSHOT'
 
 
 gradlePlugin {


### PR DESCRIPTION
I want to make sure the first Gradle plugin version is distinct from
the Bintray version (to avoid any confusion).