### PR TITLE
Set source/target compat to 1.8 for Victor

### DIFF
--- a/victor/build.gradle
+++ b/victor/build.gradle
@@ -35,6 +35,9 @@ repositories {
     mavenCentral()
 }
 
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
+
 // Batik dependencies
 
 dependencies {
@@ -75,5 +78,14 @@ pluginBundle {
     mavenCoordinates {
         groupId = "com.trello"
         artifactId = "victor"
+    }
+}
+
+publishing {
+    repositories {
+        maven {
+            name = 'localPluginRepository'
+            url = '../local-plugin-repository'
+        }
     }
 }


### PR DESCRIPTION
Otherwise this might not work with Android builds, apparently!

Also added ability to quickly publish locally, just in case I need to check
the build out myself.